### PR TITLE
Update to dotnetcore3.1, rm project filter in test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Battleship.Ascii/bin/Debug/netcoreapp2.1/Battleship.Ascii.dll",
+            "program": "${workspaceFolder}/Battleship.Ascii/bin/Debug/netcoreapp3.1/Battleship.Ascii.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Battleship.Ascii",
             // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window

--- a/Battleship.Ascii.Tests/Battleship.Ascii.Tests.csproj
+++ b/Battleship.Ascii.Tests/Battleship.Ascii.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Battleship.Ascii/Battleship.Ascii.csproj
+++ b/Battleship.Ascii/Battleship.Ascii.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Battleship.GameController.Tests/Battleship.GameController.Tests.csproj
+++ b/Battleship.GameController.Tests/Battleship.GameController.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/buildpipeline.yml
+++ b/buildpipeline.yml
@@ -29,10 +29,7 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: Test
   inputs:
-    command: test
-    projects: |
-      '**/*[Tt]ests/*.csproj'
-      '**/*ATDD/*.csproj'            
+    command: test    
     arguments: '--configuration $(BuildConfiguration)'
 
 - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Updated the project references to dotnetcore 3.1.  This removes build warnings for EoL in AzDO.

Updated the buildpipeline.yml file to remove the projects filter.  Tests were being ignored in the builds I set up this week, and removing the filter brought them right back with attachments of test results to a build.